### PR TITLE
Correggi riferimento immagine carota

### DIFF
--- a/typewrtiterCAA.html
+++ b/typewrtiterCAA.html
@@ -290,7 +290,7 @@
       { cat: "O", label: "l'arancia", speak: "l'arancia", image: "arancia.jpg" },
       { cat: "O", label: "la banana", speak: "la banana", image: "banana.jpg" },
       { cat: "O", label: "la mela", speak: "la mela", image: "mela.jpg" },
-      { cat: "O", label: "la carota", speak: "la carota", image: "carrota.jpg" }, // attenzione: nel tuo codice era "carrota.jpg"
+      { cat: "O", label: "la carota", speak: "la carota", image: "carota.jpg" },
       { cat: "O", label: "la caramella", speak: "la caramella", image: "caramella.jpg" },
       { cat: "O", label: "gli spaghetti", speak: "gli spaghetti", image: "spaghetti.jpg" },
       { cat: "O", label: "il cioccolatino", speak: "il cioccolatino", image: "cioccolatino.jpg" },


### PR DESCRIPTION
## Summary
- Usa il nome file corretto `carota.jpg` nel catalogo di immagini

## Testing
- `node - <<'NODE'
const fs = require('fs');
const html = fs.readFileSync('typewrtiterCAA.html','utf8');
const match = html.match(/la carota[^\n]*image: "([^"]+)"/);
console.log('immagine carota ->', match? match[1] : 'non trovata');
NODE`
- `curl -I https://www.vitopalumbo.it/INCLUSIONE/carota.jpg` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ad1dab6483268df4be71f97b082e