### PR TITLE
Add ARASAAC attribution footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,15 @@
       font-size:.92rem; color:#666; margin-top:.5rem;
     }
 
+    footer{
+      text-align:center;
+      padding:1rem;
+      margin-top:2rem;
+      font-size:.9rem;
+      background:var(--panel);
+      border-top:1px solid var(--border);
+    }
+
     /* Alto contrasto */
     .high-contrast{
       --bg:#000; --fg:#fff; --panel:#000; --border:#888; --shadow:none;
@@ -677,6 +686,12 @@
     renderOutput();
 
   </script>
+
+  <footer>
+    Pittogrammi di <a href="https://arasaac.org" target="_blank" rel="noopener">ARASAAC</a>
+    – licenza <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noopener">CC BY‑NC‑SA 4.0</a>
+    – © Gobierno de Aragón. Uso consentito solo per scopi non commerciali.
+  </footer>
 
   <!-- =========================
        NOTE TECNICHE


### PR DESCRIPTION
## Summary
- add footer attributing ARASAAC icons with CC BY-NC-SA 4.0 license and non-commercial notice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2b5d946788326bc17f62daf79430c