### PR TITLE
docs: add ARASAAC attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ npm test
 ```
 
 Attualmente il comando visualizza un messaggio di placeholder. In futuro lo script potrà essere ampliato per includere operazioni di linting o test unitari.
+
+## Attribuzione
+
+I pittogrammi presenti nell'applicazione provengono da [ARASAAC](https://arasaac.org) e sono distribuiti con licenza [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/). L'utilizzo è consentito solo per scopi non commerciali.
+


### PR DESCRIPTION
## Summary
- add attribution section noting ARASAAC pictogram source and CC BY-NC-SA 4.0 license restrictions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2b5db64ec8326ab1c55d3399d0d7c